### PR TITLE
Add local Kupo setup and update config

### DIFF
--- a/config.base.yaml
+++ b/config.base.yaml
@@ -18,7 +18,7 @@ frost_address: addr1v8eh3vtc30n055hz7cn5us8w3lqgmuzcsrs259q64qsh8uqlzgc6r
   # This is the address of your current FROST public key. The key generation process will print it.
   # Every node must agree on this.
 kupo:
-  kupo_address: https://kupo1ttl6wwyprf2x7rmn0da.mainnet-v2.kupo-m1.demeter.run
+  kupo_address: http://host.docker.internal:1442
   retries: 3
   timeout_ms: 5000
 logs:

--- a/run-kupo-local.sh
+++ b/run-kupo-local.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Script to run Kupo locally using Docker
+# This connects to the Cardano node socket and exposes Kupo on port 1442
+
+docker run -d \
+  --name kupo-local \
+  -p 1442:1442 \
+  -v /Users/rjlacanlaled/.dmtr/tmp/faithful-category-622fa8/mainnet-zuist1.socket:/node.socket \
+  -v $(pwd)/mainnet-config:/config \
+  -v $(pwd)/volumes/kupo-db:/db \
+  cardanosolutions/kupo \
+  --node-socket /node.socket \
+  --node-config /config/config.json \
+  --since 148027022.9b06accfd37ecbeecd5a1c7bc12c70381cd932e5ae07883f19368d634d584a53 \
+  --host 0.0.0.0 \
+  --match "e0302560ced2fdcbfcb2602697df970cd0d6a38f94b32703f51c312b/*" \
+  --match "e1317b152faac13426e6a83e06ff88a4d62cce3c1634ab0a5ec13309/*" \
+  --match "6b9c456aa650cb808a9ab54326e039d5235ed69f069c9664a8fe5b69/*" \
+  --workdir /db \
+  --defer-db-indexes \
+  --prune-utxo
+
+echo "Kupo started. Check logs with: docker logs -f kupo-local"
+echo "Kupo API available at: http://localhost:1442"


### PR DESCRIPTION
- Created run-kupo-local.sh script to run Kupo locally with Docker
- Updated config.base.yaml to use local Kupo instance (host.docker.internal:1442)
- This solves the Docker socket mounting issue on macOS

The script mounts the Cardano node socket directly and runs Kupo outside the docker-compose network for better compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)